### PR TITLE
fjs-core-1 Added basic component template replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Frontend-js Core
+A simple, minimalist frontend framework.
+
+## Options
+```js
+{
+    name: 'component-name',
+    template: '<div class="component-name">{{ hello }}</div>',
+    data: {
+        hello: 'Hello World'
+    },
+    styles: '',
+    components: {}
+}
+```
+- `root` - A DOM element to attach the component to.  Uses query selectors to append.
+- `template` - A string template that is used to generate the component html.  Can include child components.
+- `data` - Any values that the component may want to parse inside the template.
+- `styles` - A stylesheet that will be converted to an inline style element when rendered.
+- `components` - An object with child components to render into the template.
+    ```js
+    // index.js
+    import Navigation from './components/navigation'
+    import Footer from './components/footer'
+    ...
+    components: {
+        'fjs-navigation': Navigation,
+        Footer
+    }
+    ```
+    Used like this in template:
+    ```html
+    <!-- component.html -->
+    <div>
+        <fjs-navigation />
+        <Footer></Footer>
+    </div>
+    ```

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode=production",
-    "dev": "webpack --mode=development"
+    "dev": "webpack --mode=development",
+    "dev:watch": "webpack --mode-development --watch"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/frontend-js/core.git"
   },
   "author": "Luke Mckeen",
+  "contributors": [
+    "Jaclyn Staples <jaclynonacloud@gmail.com> (http://jaclynonacloud.github.io)"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/frontend-js/core/issues"


### PR DESCRIPTION
for child components and added a readme.

# Details
Made available child component use to generate parent components.  Like this!
![image](https://user-images.githubusercontent.com/6993951/95169658-9b28fa00-0789-11eb-80dd-6b7816022bf4.png)

An alternative way to scaffold out a page/component.   I just wanted to use components because I hate your load in system with root in the main `index.js` haha.

# Changes
* Added a `components` object to the `Component` class so that child components can be specified and used in the template.
  * Can use both their inferred name in the import and a given name on the object.
  * Can currently accept a self-closing tag, and a regular tag.

# Notes
> If this is accepted, there are a whole lot of follow up issues that will need to be addressed haha.  > : )  I'm gonna go to bed now.